### PR TITLE
add: dataloader using pure webdataset apis

### DIFF
--- a/laion-webdataset-pt.ipynb
+++ b/laion-webdataset-pt.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fb566193-5405-4dcf-9cef-ae30c5919a4e",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "* https://github.com/webdataset/webdataset-tensorflow/blob/main/resnet-multi.py\n",
+    "* https://github.com/LAION-AI/LAION-SAFETY/blob/main/laionsafety.py\n",
+    "\n",
+    "## Machine used\n",
+    "\n",
+    "00071-gpu machine on Spell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f0fdde1b-12c7-4ae4-a5e4-f30a180c4152",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import numpy as np\n",
+    "import pprint\n",
+    "import webdataset as wds\n",
+    "from webdataset import multi\n",
+    "import typer\n",
+    "\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "444a2022-4060-4dbb-97a8-e3f49efd0223",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PATH = \"../dataset/{00000..00046}.tar\"\n",
+    "BATCH_SIZE = 512"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "51dd32f9-09b7-444c-bc99-4cfe8e19589b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def filter_dataset(item):  # For e.g. C@H which (rarely) has no caption available.\n",
+    "    if \"txt\" not in item:\n",
+    "        return False\n",
+    "    if \"jpg\" not in item:\n",
+    "        return False\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b1deea1a-6a7e-4942-b62e-47821002fa93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = wds.WebDataset(PATH, handler=wds.ignore_and_continue).select(filter_dataset).decode('rgb').to_tuple('jpg', 'txt')\n",
+    "dataloader = wds.WebLoader(dataset, shuffle=False, num_workers=os.cpu_count(), batch_size=BATCH_SIZE, prefetch_factor=4*BATCH_SIZE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6dc038ec-ac80-41cf-9c4f-da2a82a98f6c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([512, 256, 256, 3])\n",
+      "512\n"
+     ]
+    }
+   ],
+   "source": [
+    "for image_batch, caption_batch in dataloader:\n",
+    "    print(image_batch.shape)\n",
+    "    print(len(caption_batch))\n",
+    "    break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c78827b6-2450-431c-afa0-53be81c07cf0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.22 s, sys: 498 ms, total: 1.72 s\n",
+      "Wall time: 5.58 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# Benchmaring for 10 batches.\n",
+    "for i, (batch, label) in enumerate(dataloader):\n",
+    "    if i == 10:\n",
+    "        break"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "tf2-gpu.2-7.m87",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-7:m87"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
@rom1504 @christophschuhmann this PR adds a notebook that uses all WebDataset APIs to create a dataloader. The dataloader practically has no difference with [this(]https://github.com/LAION-AI/LAION-SAFETY/blob/main/laionsafety.py#L75-#L77). Even though the timings are better with this dataloader (see below) _if we were to use the TensorFlow model_ I think we are likely better off with the combined loader i.e., WebDataset + `tf.data`. Here's why

* If we have a `tf.data` loader as introduced in the [previous PR](https://github.com/LAION-AI/LAION-SAFETY/pull/3) then we don't need to iterate through it and we can call `model.predict()` directly on the loader. We can even run it in a distributed manner. The code would be something like so:

```py
with strategy.scope(): # Can be sync / sync
    predictions = model.predict(tf_loader)
```

Here are some benchmarking results. Unless explicitly specified please note that the batch size in all the settings is 512 and the number of batches is capped at 10. I used [this instance](https://web.spell.ml/SpellGrant-SP/workspaces/80) on our Spell group. 

## WebDataset + `tf.data`

**[This notebook](https://github.com/LAION-AI/LAION-SAFETY/blob/main/laion-webdataset-tf.ipynb) (`tf.data`) but the tars are read locally now**:

```
CPU times: user 15.2 s, sys: 11.9 s, total: 27.1 s
Wall time: 15.2 s
```

**Above setting without resizing**:

```
CPU times: user 5.69 s, sys: 6.48 s, total: 12.2 s
Wall time: 10.9 s
```

The rationale behind discarding the resizing op is that we can easily create a TensorFlow model like so:

```py
model = tf.keras.Sequential([layers.Resizing(260, 260), efficientnetv2_model])
```

Notice how `model` now takes care of the resizing for us. It has a negligible overhead when run on the accelerator. 

**[This notebook](https://github.com/LAION-AI/LAION-SAFETY/blob/main/laion-webdataset-tf.ipynb) but the tars are read online now**:

```
CPU times: user 16.4 s, sys: 11.7 s, total: 28.1 s
Wall time: 14.9 s
```

## Pure WebDataset

**Pure WebDataset (batch size of 512)**

```
CPU times: user 1.22 s, sys: 498 ms, total: 1.72 s
Wall time: 5.58 s
```

**Pure WebDataset (batch size of 1024)**

```
CPU times: user 4.79 s, sys: 990 ms, total: 5.78 s
Wall time: 11.1 s
```

Code for the pure WebDataset-based loader is available [here](https://github.com/sayakpaul/LAION-SAFETY/blob/main/laion-webdataset-pt.ipynb). 